### PR TITLE
Rename project to openstf

### DIFF
--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -33,7 +33,7 @@ jobs:
     # Commit documentation changes to the gh-pages branch
     - name: Commit documentation changes
       run: |
-        git clone https://github.com/alliander-opensource/short-term-forecasting.git --branch gh-pages --single-branch gh-pages
+        git clone https://github.com/alliander-opensource/openstf.git --branch gh-pages --single-branch gh-pages
         cp -r docs/_build/html/* gh-pages/
         cd gh-pages
         touch .nojekyll

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -59,7 +59,7 @@ jobs:
     # Known bug: https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
     - name: fix code coverage paths
       run: |
-        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\//g' coverage.xml
+        sed -i 's/\/home\/runner\/work\/openstf\/openstf\//\/github\/workspace\//g' coverage.xml
     # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ SPDX-License-Identifier: MPL-2.0
 -->
 
 <!-- Github Actions badges -->
-[![Python Build](https://github.com/alliander-opensource/short-term-forecasting/actions/workflows/python-build.yaml/badge.svg)](https://github.com/alliander-opensource/short-term-forecasting/actions/workflows/python-build.yaml)
-[![REUSE Compliance Check](https://github.com/alliander-opensource/short-term-forecasting/actions/workflows/reuse-compliance.yaml/badge.svg)](https://github.com/alliander-opensource/short-term-forecasting/actions/workflows/reuse-compliance.yaml)
+[![Python Build](https://github.com/alliander-opensource/openstf/actions/workflows/python-build.yaml/badge.svg)](https://github.com/alliander-opensource/openstf/actions/workflows/python-build.yaml)
+[![REUSE Compliance Check](https://github.com/alliander-opensource/openstf/actions/workflows/reuse-compliance.yaml/badge.svg)](https://github.com/alliander-opensource/openstf/actions/workflows/reuse-compliance.yaml)
 <!-- SonarCloud badges -->
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=alert_status)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=bugs)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ SPDX-License-Identifier: MPL-2.0
 [![Python Build](https://github.com/alliander-opensource/openstf/actions/workflows/python-build.yaml/badge.svg)](https://github.com/alliander-opensource/openstf/actions/workflows/python-build.yaml)
 [![REUSE Compliance Check](https://github.com/alliander-opensource/openstf/actions/workflows/reuse-compliance.yaml/badge.svg)](https://github.com/alliander-opensource/openstf/actions/workflows/reuse-compliance.yaml)
 <!-- SonarCloud badges -->
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=alert_status)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=bugs)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=code_smells)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=coverage)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
-[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
-[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=security_rating)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
-[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=sqale_index)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
-[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf&metric=alert_status)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf&metric=bugs)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf&metric=code_smells)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf&metric=coverage)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf&metric=security_rating)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf&metric=sqale_index)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_openstf&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=alliander-opensource_openstf)
 
 # Openstf
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ SPDX-License-Identifier: MPL-2.0
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=sqale_index)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=alliander-opensource_short-term-forecasting&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=alliander-opensource_short-term-forecasting)
 
-# Short Term Forcasting
+# Openstf
 
-Short term forcasting builds the `openstf` Python package which is used to make short term forecasts for the energy sector. This repository contains all components for the machine learning pipeline required to make a forecast. In order to use the package you need to provide your own data storage and retrieval interface. `openstf` is available at: https://pypi.org/project/openstf/
+Openstf is a Python package which is used to make short term forecasts for the energy sector. This repository contains all components for the machine learning pipeline required to make a forecast. In order to use the package you need to provide your own data storage and retrieval interface. `openstf` is available at: https://pypi.org/project/openstf/
 
 # Installation
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     description="Open short term forcasting",
     long_description=read_long_description_from_readme(),
     long_description_content_type="text/markdown",
-    url="https://github.com/alliander-opensource/short-term-forecasting",
+    url="https://github.com/alliander-opensource/openstf",
     author="Alliander N.V",
     author_email="korte.termijn.prognoses@alliander.com",
     license="MPL-2.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 sonar.organization=alliander-opensource
+# TODO change to alliander-opensource_openstf
 sonar.projectKey=alliander-opensource_short-term-forecasting
+sonar.projectName=openstf
 
 # relative paths to source directories. More details and properties are described
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,13 +2,15 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+sonar.projectKey=alliander-opensource_openstf
 sonar.organization=alliander-opensource
-# TODO change to alliander-opensource_openstf
-sonar.projectKey=alliander-opensource_short-term-forecasting
+
+# This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=openstf
 
 # relative paths to source directories. More details and properties are described
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
 sonar.sources=openstf
+sonar.sourceEncoding=UTF-8
 sonar.python.coverage.reportPaths=/github/workspace/coverage.xml
 sonar.tests=test/unit


### PR DESCRIPTION
This is just a small change, we already refer to this project as openstf. This PR combined with the name change of the repository aims to make our naming more clear. All our project within alliander-opensource should now begin with openstf.

> NOTE don't worry about things braking Github got us covered. Automatic redirect from the old to the new name should be in place. But it's still advised to update your git remote's and or browser bookmarks. See https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/renaming-a-repository
