### PR TITLE
Bugfix ktps 1499 basecase stdev const load

### DIFF
--- a/openstf/feature_engineering/feature_applicator.py
+++ b/openstf/feature_engineering/feature_applicator.py
@@ -120,6 +120,7 @@ class OperationalPredictFeatureApplicator(AbstractFeatureApplicator):
         )
         df = add_missing_feature_columns(df, self.feature_names)
         # NOTE this is required since apply_features could add additional features
-        df = remove_non_requested_feature_columns(df, self.feature_names)
+        if self.feature_names is not None:
+            df = remove_non_requested_feature_columns(df, self.feature_names)
 
         return enforce_feature_order(df)

--- a/openstf/model/basecase.py
+++ b/openstf/model/basecase.py
@@ -51,6 +51,7 @@ class BaseCaseModel(BaseEstimator, RegressorMixin):
         """
 
         # Validate input to make sure we are not overwriting regular forecasts
+        # TODO this should be moved to right before writing the data to the database, or at least the Task level...
         requested_start = forecast_input_data.index.min().ceil(f"{MINIMAL_RESOLUTION}T")
         allowed_start = pd.Series(
             datetime.utcnow().replace(tzinfo=pytz.utc)

--- a/openstf/model/basecase.py
+++ b/openstf/model/basecase.py
@@ -49,20 +49,6 @@ class BaseCaseModel(BaseEstimator, RegressorMixin):
 
 
         """
-
-        # Validate input to make sure we are not overwriting regular forecasts
-        # TODO this should be moved to right before writing the data to the database, or at least the Task level...
-        requested_start = forecast_input_data.index.min().ceil(f"{MINIMAL_RESOLUTION}T")
-        allowed_start = pd.Series(
-            datetime.utcnow().replace(tzinfo=pytz.utc)
-        ).min().floor(f"{MINIMAL_RESOLUTION}T").to_pydatetime() + timedelta(
-            hours=overwrite_delay_hours
-        )
-        if requested_start < allowed_start:
-            raise ValueError(
-                f"Basecase forecast requested for horizon of regular forecast! Please check input! Requested start {requested_start}, allowed start {allowed_start}"
-            )
-
         # Check if required features are provided
         if not all(
             item in forecast_input_data.columns.to_list() for item in ["T-14d", "T-7d"]

--- a/openstf/model/confidence_interval_applicator.py
+++ b/openstf/model/confidence_interval_applicator.py
@@ -90,24 +90,13 @@ class ConfidenceIntervalApplicator:
             return forecast
 
         # -------- Moved from feature_engineering.add_stdev ------------------------- #
-        # pivot
+        # pivot. idea is to have a dataframe with columns [stdev, hour, horizon] for a 'near' and a 'far' horizon
         stdev = standard_deviation.pivot_table(columns=["horizon"], index="hour")[
             "stdev"
         ]
-        # Prepare input dataframes
-        # Rename Near and Far to 0.25 and 47 respectively, if present.
-        # Timehorizon in hours is preferred to less descriptive Near/Far
-        if "Near" in stdev.columns:
-            near = (forecast.index[1] - forecast.index[0]).total_seconds() / 3600.0
-            # Try to infer for forecast df, else use a max of 48 hours
-            far = min(
-                48.0,
-                (forecast.index.max() - forecast.index.min()).total_seconds() / 3600.0,
-            )
-            stdev.rename(columns={"Near": near, "Far": far}, inplace=True)
-        else:
-            near = stdev.columns.min()
-            far = stdev.columns.max()
+        # Prepare input dataframes for near and far horizon
+        near = stdev.columns.min()
+        far = stdev.columns.max()
 
         forecast_copy = forecast.copy()
         # add time ahead column if not already present

--- a/openstf/pipeline/create_basecase_forecast.py
+++ b/openstf/pipeline/create_basecase_forecast.py
@@ -43,7 +43,9 @@ def create_basecase_forecast_pipeline(
     logger.info("Preprocessing data for basecase forecast")
     # Validate and clean data - use a very long flatliner threshold.
     # If a measurement was constant for a long period, a basecase should still be made.
-    validated_data = validation.validate(input_data, flatliner_threshold=4*24*14+1)
+    validated_data = validation.validate(
+        input_data, flatliner_threshold=4 * 24 * 14 + 1
+    )
 
     # Add features
     data_with_features = OperationalPredictFeatureApplicator(
@@ -55,7 +57,7 @@ def create_basecase_forecast_pipeline(
     ).add_features(validated_data)
 
     # Only try to make a forecast for moments where load = nan
-    forecast_input = data_with_features.loc[data_with_features['load'].isna(), :]
+    forecast_input = data_with_features.loc[data_with_features["load"].isna(), :]
 
     # Initialize model
     model = BaseCaseModel()

--- a/openstf/pipeline/create_basecase_forecast.py
+++ b/openstf/pipeline/create_basecase_forecast.py
@@ -26,7 +26,8 @@ BASECASE_RESOLUTION_MINUTES = 15
 
 
 def create_basecase_forecast_pipeline(
-    pj: dict, input_data: pd.DataFrame,
+    pj: dict,
+    input_data: pd.DataFrame,
 ) -> pd.DataFrame:
     """Computes the base case forecast and confidence intervals for a given prediction job and input data.
 
@@ -59,8 +60,10 @@ def create_basecase_forecast_pipeline(
     # Similarly to the forecast pipeline, only try to make a forecast for moments in the future
     # TODO, do we want to be this strict on time window of forecast in this place?
     # see issue https://github.com/alliander-opensource/openstf/issues/121
-    start, end = generate_forecast_datetime_range(resolution_minutes=BASECASE_RESOLUTION_MINUTES,
-                                                  horizon_minutes=BASECASE_HORIZON_MINUTES)
+    start, end = generate_forecast_datetime_range(
+        resolution_minutes=BASECASE_RESOLUTION_MINUTES,
+        horizon_minutes=BASECASE_HORIZON_MINUTES,
+    )
     forecast_input = data_with_features[start:end]
 
     # Initialize model

--- a/openstf/pipeline/create_basecase_forecast.py
+++ b/openstf/pipeline/create_basecase_forecast.py
@@ -91,7 +91,6 @@ def create_basecase_forecast_pipeline(
         pj=pj,
         forecast=basecase_forecast,
         algorithm_type="basecase_lastweek",
-        forecast_type=ForecastType.BASECASE,
         forecast_quality="not_renewed",
     )
 

--- a/openstf/tasks/create_basecase_forecast.py
+++ b/openstf/tasks/create_basecase_forecast.py
@@ -19,6 +19,7 @@ Example:
         $ python create_basecase_forecast.py
 """
 from datetime import datetime, timedelta
+import pandas as pd
 
 from openstf.pipeline.create_basecase_forecast import create_basecase_forecast_pipeline
 from openstf.tasks.utils.predictionjobloop import PredictionJobLoop
@@ -50,6 +51,11 @@ def create_basecase_forecast_task(pj: dict, context: TaskContext) -> None:
 
     # Make basecase forecast using the corresponding pipeline
     basecase_forecast = create_basecase_forecast_pipeline(pj, input_data)
+
+    # Do not store basecase forecasts for moments within next 48 hours.
+    # Those should be updated by regular forecast process.
+    basecase_forecast = basecase_forecast.loc[basecase_forecast.index > (pd.to_datetime(datetime.utcnow(), utc=True) + timedelta(hours=48)), :]
+
 
     # Write basecase forecast to the database
     context.database.write_forecast(basecase_forecast, t_ahead_series=True)

--- a/openstf/tasks/create_basecase_forecast.py
+++ b/openstf/tasks/create_basecase_forecast.py
@@ -54,8 +54,11 @@ def create_basecase_forecast_task(pj: dict, context: TaskContext) -> None:
 
     # Do not store basecase forecasts for moments within next 48 hours.
     # Those should be updated by regular forecast process.
-    basecase_forecast = basecase_forecast.loc[basecase_forecast.index > (pd.to_datetime(datetime.utcnow(), utc=True) + timedelta(hours=48)), :]
-
+    basecase_forecast = basecase_forecast.loc[
+        basecase_forecast.index
+        > (pd.to_datetime(datetime.utcnow(), utc=True) + timedelta(hours=48)),
+        :,
+    ]
 
     # Write basecase forecast to the database
     context.database.write_forecast(basecase_forecast, t_ahead_series=True)

--- a/openstf/validation/validation.py
+++ b/openstf/validation/validation.py
@@ -21,7 +21,9 @@ MINIMAL_TABLE_LENGTH = 100
 FLATLINER_TRESHOLD = 24
 
 
-def validate(data: pd.DataFrame, flatliner_threshold: int=FLATLINER_TRESHOLD) -> pd.DataFrame:
+def validate(
+    data: pd.DataFrame, flatliner_threshold: int = FLATLINER_TRESHOLD
+) -> pd.DataFrame:
     logger = structlog.get_logger(__name__)
     # Drop 'false' measurements. e.g. where load appears to be constant.
     data = replace_repeated_values_with_nan(

--- a/openstf/validation/validation.py
+++ b/openstf/validation/validation.py
@@ -21,12 +21,11 @@ MINIMAL_TABLE_LENGTH = 100
 FLATLINER_TRESHOLD = 24
 
 
-def validate(data: pd.DataFrame) -> pd.DataFrame:
+def validate(data: pd.DataFrame, flatliner_threshold: int=FLATLINER_TRESHOLD) -> pd.DataFrame:
     logger = structlog.get_logger(__name__)
     # Drop 'false' measurements. e.g. where load appears to be constant.
-    threshold = 6 * 4  # number of repeated values
     data = replace_repeated_values_with_nan(
-        data, max_length=threshold, column_name=data.columns[0]
+        data, max_length=flatliner_threshold, column_name=data.columns[0]
     )
     num_const_load_values = len(data) - len(data.iloc[:, 0].dropna())
     logger.debug(
@@ -35,7 +34,7 @@ def validate(data: pd.DataFrame) -> pd.DataFrame:
     )
 
     # Check for repeated load observations due to invalid measurements
-    suspicious_moments = find_nonzero_flatliner(data, threshold=FLATLINER_TRESHOLD)
+    suspicious_moments = find_nonzero_flatliner(data, threshold=flatliner_threshold)
     if suspicious_moments is not None:
         # Covert repeated load observations to NaN values
         data = replace_invalid_data(data, suspicious_moments)

--- a/test/unit/pipeline/test_create_basecase.py
+++ b/test/unit/pipeline/test_create_basecase.py
@@ -65,3 +65,18 @@ class TestBaseCaseForecast(BaseTestCase):
 
         # Test forecast quality label
         self.assertEqual(base_case_forecast["quality"][0], "not_renewed")
+
+    def test_create_basecase_forecast_pipeline_constant_load(self):
+        """Historic load can be constant, basecase should still be possible"""
+        # Generic prep for test
+        PJ = TestData.get_prediction_job(pid=307)
+        forecast_input = TestData.load("reference_sets/307-test-data.csv")
+        PJ["model_type_group"] = "default"
+
+        # change historic load to be constant for last 14days
+        forecast_input.loc[forecast_input.index.max()-timedelta(days=14):, 'load'] = forecast_input.loc[forecast_input.index.max()-timedelta(days=14), 'load']
+
+        base_case_forecast = create_basecase_forecast_pipeline(PJ, forecast_input)
+
+        # add some asserts
+        self.assertListEqual(base_case_forecast.columns, [''])

--- a/test/unit/pipeline/test_create_basecase.py
+++ b/test/unit/pipeline/test_create_basecase.py
@@ -12,19 +12,23 @@ from openstf.pipeline.create_basecase_forecast import create_basecase_forecast_p
 
 
 class TestBaseCaseForecast(BaseTestCase):
-
     def setUp(self) -> None:
         super().setUp()
         # Generic prep for test
         pj = TestData.get_prediction_job(pid=307)
         forecast_input = TestData.load("reference_sets/307-test-data.csv")
         # Set last 7 days to nan, just like operationally
-        forecast_input.loc[forecast_input.index.max()-timedelta(days=7):, 'load'] = np.nan
+        forecast_input.loc[
+            forecast_input.index.max() - timedelta(days=7) :, "load"
+        ] = np.nan
         # Shift so the input matches 'now'
-        offset_seconds = (pd.to_datetime(datetime.utcnow(), utc=True) -
-                          (forecast_input.index.max()-timedelta(days=7))).total_seconds()
-        forecast_input = forecast_input.shift(freq='T',
-                                              periods=int(int(offset_seconds/60./15.)*15))
+        offset_seconds = (
+            pd.to_datetime(datetime.utcnow(), utc=True)
+            - (forecast_input.index.max() - timedelta(days=7))
+        ).total_seconds()
+        forecast_input = forecast_input.shift(
+            freq="T", periods=int(int(offset_seconds / 60.0 / 15.0) * 15)
+        )
         pj["model_type_group"] = "default"
 
         self.PJ = pj
@@ -33,7 +37,9 @@ class TestBaseCaseForecast(BaseTestCase):
     def test_basecase_pipeline_happy_flow(self):
         """Test happy flow - everything should work just fine"""
 
-        base_case_forecast = create_basecase_forecast_pipeline(self.PJ, self.forecast_input)
+        base_case_forecast = create_basecase_forecast_pipeline(
+            self.PJ, self.forecast_input
+        )
 
         # Test length of the output
         self.assertEqual(len(base_case_forecast), 673)
@@ -72,9 +78,12 @@ class TestBaseCaseForecast(BaseTestCase):
         # Change load of inputdata so at the end,
         # 14 days are constant and then 7 days are nan
         forecast_input = self.forecast_input.copy()
-        forecast_input.loc[forecast_input.index.max()-timedelta(days=21):, 'load'] =\
-            forecast_input.loc[forecast_input.index.max()-timedelta(days=14), 'load']
-        forecast_input.loc[forecast_input.index.max()-timedelta(days=7):, 'load'] = np.nan
+        forecast_input.loc[
+            forecast_input.index.max() - timedelta(days=21) :, "load"
+        ] = forecast_input.loc[forecast_input.index.max() - timedelta(days=14), "load"]
+        forecast_input.loc[
+            forecast_input.index.max() - timedelta(days=7) :, "load"
+        ] = np.nan
 
         base_case_forecast = create_basecase_forecast_pipeline(self.PJ, forecast_input)
 

--- a/test/unit/pipeline/test_create_basecase.py
+++ b/test/unit/pipeline/test_create_basecase.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from datetime import datetime, timedelta
 
-from openstf.pipeline.create_basecase_forecast import create_basecase_forecast_pipeline, BaseCaseNoForecastException
+from openstf.pipeline.create_basecase_forecast import create_basecase_forecast_pipeline
 
 
 class TestBaseCaseForecast(BaseTestCase):
@@ -36,7 +36,7 @@ class TestBaseCaseForecast(BaseTestCase):
         base_case_forecast = create_basecase_forecast_pipeline(self.PJ, self.forecast_input)
 
         # Test length of the output
-        self.assertEqual(len(base_case_forecast), 480)
+        self.assertEqual(len(base_case_forecast), 673)
 
         # Test available columns
         self.assertEqual(
@@ -79,18 +79,5 @@ class TestBaseCaseForecast(BaseTestCase):
         base_case_forecast = create_basecase_forecast_pipeline(self.PJ, forecast_input)
 
         # Check for length
-        self.assertEqual(len(base_case_forecast), 480)
-        self.assertEqual(len(base_case_forecast.dropna()), 480)
-
-    def test_create_basecase_forecast_pipeline_exception_for_empty_forecast(self):
-        """An empty basecase input (after validation) should yield an exception"""
-        forecast_input = self.forecast_input
-        # Set last 21days to nan
-        forecast_input.loc[forecast_input.index.max()-timedelta(days=21):, 'load'] = np.nan
-
-        try:
-            create_basecase_forecast_pipeline(self.PJ, forecast_input)
-            raise Exception('A BaseCaseNoForecastException should have been raised')
-        except BaseCaseNoForecastException:
-            # This is expected
-            pass
+        self.assertEqual(len(base_case_forecast), 673)
+        self.assertEqual(len(base_case_forecast.dropna()), 673)

--- a/test/unit/tasks/test_create_basecase_forecast.py
+++ b/test/unit/tasks/test_create_basecase_forecast.py
@@ -3,13 +3,18 @@
 # SPDX-License-Identifier: MPL-2.0
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
+import pandas as pd
+from datetime import datetime, timedelta
 
 from openstf.tasks.create_basecase_forecast import create_basecase_forecast_task
 
 from test.utils import TestData
 
-FORECAST_MOCK = "forecast_mock"
-
+# Specify forecast mock.
+# Make sure this has a datetime of at least NOW+48hours,
+# since this is filtered in the task
+FORECAST_MOCK = pd.DataFrame(index=pd.to_datetime([datetime.utcnow()], utc=True)+timedelta(days=3), data=dict(forecast=[10.0]))
+FORECAST_NEAR_FUTURE_MOCK = pd.DataFrame(index=pd.to_datetime([datetime.utcnow()], utc=True)+timedelta(days=1), data=dict(forecast=[10.0]))
 
 class TestCreateBasecaseForecastTask(TestCase):
     def setUp(self) -> None:
@@ -23,4 +28,17 @@ class TestCreateBasecaseForecastTask(TestCase):
         # Test happy flow of create forecast task
         context = MagicMock()
         create_basecase_forecast_task(self.pj, context)
-        self.assertEqual(context.mock_calls[1].args[0], FORECAST_MOCK)
+        pd.testing.assert_frame_equal(context.mock_calls[1].args[0], FORECAST_MOCK)
+
+    @patch(
+        "openstf.tasks.create_basecase_forecast.create_basecase_forecast_pipeline",
+        MagicMock(return_value=FORECAST_NEAR_FUTURE_MOCK),
+    )
+    def test_create_basecase_forecast_no_forecasts_first_48_hours(self):
+        """If the basecase forecast pipeline returns forecasts within next 48 hours,
+        those should not be written to database"""
+        context = MagicMock()
+        create_basecase_forecast_task(self.pj, context)
+
+        # Mock call should be empty dataframe
+        self.assertEqual(context.mock_calls[1].args[0].empty, True)

--- a/test/unit/tasks/test_create_basecase_forecast.py
+++ b/test/unit/tasks/test_create_basecase_forecast.py
@@ -13,8 +13,15 @@ from test.utils import TestData
 # Specify forecast mock.
 # Make sure this has a datetime of at least NOW+48hours,
 # since this is filtered in the task
-FORECAST_MOCK = pd.DataFrame(index=pd.to_datetime([datetime.utcnow()], utc=True)+timedelta(days=3), data=dict(forecast=[10.0]))
-FORECAST_NEAR_FUTURE_MOCK = pd.DataFrame(index=pd.to_datetime([datetime.utcnow()], utc=True)+timedelta(days=1), data=dict(forecast=[10.0]))
+FORECAST_MOCK = pd.DataFrame(
+    index=pd.to_datetime([datetime.utcnow()], utc=True) + timedelta(days=3),
+    data=dict(forecast=[10.0]),
+)
+FORECAST_NEAR_FUTURE_MOCK = pd.DataFrame(
+    index=pd.to_datetime([datetime.utcnow()], utc=True) + timedelta(days=1),
+    data=dict(forecast=[10.0]),
+)
+
 
 class TestCreateBasecaseForecastTask(TestCase):
     def setUp(self) -> None:

--- a/test/utils/base.py
+++ b/test/utils/base.py
@@ -36,8 +36,9 @@ class BaseTestCase(unittest.TestCase):
 
     def tearDown(self) -> None:
         super().tearDown()
-        for patcher in self.patchers:
-            patcher.stop()
+        if hasattr(self, "patchers"):
+            for patcher in self.patchers:
+                patcher.stop()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
There was a bug where basecase_task gave exception if load was constant.
By solving that bug, other issues showed, which were also tackled in this PR.

Major:
- if basecase if stored, `algtype` should be basecase, but `type` should be pj['typ']
- basecase should not be stored for t < NOW+48hours. However, before this PR is wasn't possible to make a basecase forecast for those moments, while we do want that option for e.g. backtests. This responsibility is moved to the task-level
- improved `validate` step, so basecase can also be made when load is constant

Minor:
- there were some old and obsolete references to horizon = 'near' or 'far'. These have been updated to be in t_ahead_hours, reference is therefore removed.

Also added unit tests to test desired behavior of pipeline and task
