### PR TITLE
Bugfix ktps 1497 hyperparam issue first times

### DIFF
--- a/openstf/tasks/optimize_hyperparameters.py
+++ b/openstf/tasks/optimize_hyperparameters.py
@@ -39,7 +39,12 @@ def optimize_hyperparameters_task(pj: dict, context: TaskContext) -> None:
 
     # Determine if we need to optimize hyperparams
     datetime_last_optimized = context.database.get_hyper_params_last_optimized(pj)
-    last_optimized_days = (datetime.utcnow() - datetime_last_optimized).days
+    try:
+        last_optimized_days = (datetime.utcnow() - datetime_last_optimized).days
+    except TypeError:
+        # This happens when no old hyperparams are found.
+        # In that case, set last_optimized_days to exceed the threshold
+        last_optimized_days = MAX_AGE_HYPER_PARAMS_DAYS + 1
 
     if last_optimized_days < MAX_AGE_HYPER_PARAMS_DAYS:
         context.logger.warning(

--- a/openstf/tasks/optimize_hyperparameters.py
+++ b/openstf/tasks/optimize_hyperparameters.py
@@ -21,7 +21,6 @@ from datetime import datetime, timedelta
 from openstf.pipeline.optimize_hyperparameters import optimize_hyperparameters_pipeline
 from openstf.tasks.utils.predictionjobloop import PredictionJobLoop
 from openstf.tasks.utils.taskcontext import TaskContext
-from openstf.monitoring import teams
 
 MAX_AGE_HYPER_PARAMS_DAYS = 31
 
@@ -74,13 +73,6 @@ def optimize_hyperparameters_task(pj: dict, context: TaskContext) -> None:
     hyperparameters = optimize_hyperparameters_pipeline(pj, input_data)
 
     context.database.write_hyper_params(pj, hyperparameters)
-
-    # Sent message to Teams
-    title = (
-        f'Optimized hyperparameters for prediction job {pj["name"]} {pj["description"]}'
-    )
-
-    teams.post_teams(teams.format_message(title=title, params=hyperparameters))
 
 
 def main():

--- a/test/unit/tasks/test_optimize_hyperparameters.py
+++ b/test/unit/tasks/test_optimize_hyperparameters.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from datetime import datetime, timedelta
 
-from test.utils import BaseTestCase, TestData
+from test.utils import TestData
 from openstf.tasks.optimize_hyperparameters import optimize_hyperparameters_task
 
 HYPERPARAM_MOCK = dict(float_param=1.0, string_param="string")

--- a/test/unit/tasks/test_optimize_hyperparameters.py
+++ b/test/unit/tasks/test_optimize_hyperparameters.py
@@ -45,10 +45,16 @@ class TestOptimizeHyperparametersTask(TestCase):
             context.mock_calls[1].args[0], "Skip hyperparameter optimization"
         )
 
+    @patch(
+        "openstf.tasks.optimize_hyperparameters.optimize_hyperparameters_pipeline",
+        MagicMock(return_value=HYPERPARAM_MOCK),
+    )
     def test_optimize_hyperparams_no_old_params(self):
+        """If no old hyperparams exist, new hyperparams should be optimized"""
         context = self.context
         # Set old param age to None
         context.database.get_hyper_params_last_optimized.return_value = None
 
         optimize_hyperparameters_task(self.pj, context)
-        assert True
+        # Same as happy flow, evaluate the pipeline has written hyperparams
+        self.assertDictEqual(context.mock_calls[5].args[-1], HYPERPARAM_MOCK)

--- a/test/unit/tasks/test_optimize_hyperparameters.py
+++ b/test/unit/tasks/test_optimize_hyperparameters.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2017-2021 Alliander N.V. <korte.termijn.prognoses@alliander.com> # noqa E501>
+#
+# SPDX-License-Identifier: MPL-2.0
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timedelta
+
+from test.utils import BaseTestCase, TestData
+from openstf.tasks.optimize_hyperparameters import optimize_hyperparameters_task
+
+HYPERPARAM_MOCK = dict(float_param=1.0, string_param="string")
+
+
+class TestOptimizeHyperparametersTask(TestCase):
+    def setUp(self) -> None:
+        self.pj = TestData.get_prediction_job(pid=307)
+        self.context = MagicMock()
+        # Define default return values that make sense for happy flow
+        LAST_OPTIMIZED_AGO_DAYS = 35
+        self.context.database.get_hyper_params_last_optimized.return_value = (
+            datetime.utcnow() - timedelta(days=LAST_OPTIMIZED_AGO_DAYS)
+        )
+
+    @patch(
+        "openstf.tasks.optimize_hyperparameters.optimize_hyperparameters_pipeline",
+        MagicMock(return_value=HYPERPARAM_MOCK),
+    )
+    def test_optimize_hyperparameters_happy_flow(self):
+        # Test happy flow of create forecast task
+        context = self.context
+
+        optimize_hyperparameters_task(self.pj, context)
+        # Assert call 5 (write hyperparams to db) matches hyperparam mock
+        self.assertDictEqual(context.mock_calls[5].args[-1], HYPERPARAM_MOCK)
+
+    def test_optimize_hyperparameters_new_params(self):
+        """If new params are available, do nothing"""
+        context = self.context
+        # Set old param age to 2 days
+        context.database.get_hyper_params_last_optimized.return_value = (
+            datetime.utcnow() - timedelta(days=2)
+        )
+        optimize_hyperparameters_task(self.pj, context)
+        self.assertEqual(
+            context.mock_calls[1].args[0], "Skip hyperparameter optimization"
+        )
+
+    def test_optimize_hyperparams_no_old_params(self):
+        context = self.context
+        # Set old param age to None
+        context.database.get_hyper_params_last_optimized.return_value = None
+
+        optimize_hyperparameters_task(self.pj, context)
+        assert True


### PR DESCRIPTION
if no old hyperparams were available, this would lead to an exception. 
Now, it does not lead to an exception anymore.

Commits include reproducing the issue and subsequently solving it.
Moreover, no unit tests were available for the task, so I added those as well.

!!! Note, the post_teams dependency in optimize_hyperparameters_task caused issues in unit testing.
This dependency is undesirable in the first place, and also not required by KTP operationally.
I removed this dependency altogether in this PR. Please raise a point if you disagree with this.