### PR TITLE
raise distinct exceptions for calc kpi

### DIFF
--- a/openstf/exceptions.py
+++ b/openstf/exceptions.py
@@ -6,6 +6,8 @@
 These are not complete, but will be added on a case by case basis
 """
 
+from typing import Union
+
 # Define custom exception
 class NoPredictionException(Exception):
     """Custom exception if no historic predictions are available
@@ -15,7 +17,9 @@ class NoPredictionException(Exception):
     """
 
     def __init__(
-        self, pid, message="No historic predictions found." "Could not calc KPI"
+        self,
+        pid: Union[int, str],
+        message: str = "No historic predictions found." "Could not calc KPI",
     ):
         self.pid = pid
         self.message = message
@@ -29,7 +33,11 @@ class NoLoadException(Exception):
         message -- explanation of the error
     """
 
-    def __init__(self, pid, message="No historic load found." "Could not calc KPI"):
+    def __init__(
+        self,
+        pid: Union[int, str],
+        message: str = "No historic load found." "Could not calc KPI",
+    ):
         self.pid = pid
         self.message = message
         super().__init__(self.message)

--- a/openstf/exceptions.py
+++ b/openstf/exceptions.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2021 Alliander N.V. <korte.termijn.prognoses@alliander.com> # noqa E501>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 """Define custom exception classes.
 These are not complete, but will be added on a case by case basis
 """

--- a/openstf/exceptions.py
+++ b/openstf/exceptions.py
@@ -1,0 +1,31 @@
+"""Define custom exception classes.
+These are not complete, but will be added on a case by case basis
+"""
+
+# Define custom exception
+class NoPredictionException(Exception):
+    """Custom exception if no historic predictions are available
+    Attributes:
+        pid -- prediction job id for which the exception occurred
+        message -- explanation of the error
+    """
+
+    def __init__(
+        self, pid, message="No historic predictions found." "Could not calc KPI"
+    ):
+        self.pid = pid
+        self.message = message
+        super().__init__(self.message)
+
+
+class NoLoadException(Exception):
+    """Custom Exception if no historic load is available
+    Attributes:
+        pid -- prediction job id for which the exception occurred
+        message -- explanation of the error
+    """
+
+    def __init__(self, pid, message="No historic load found." "Could not calc KPI"):
+        self.pid = pid
+        self.message = message
+        super().__init__(self.message)

--- a/openstf/tasks/calculate_kpi.py
+++ b/openstf/tasks/calculate_kpi.py
@@ -31,6 +31,7 @@ from openstf.validation import validation
 from openstf.metrics import metrics
 from openstf.tasks.utils.predictionjobloop import PredictionJobLoop
 from openstf.tasks.utils.taskcontext import TaskContext
+from openstf.exceptions import NoLoadException, NoPredictionException
 
 # Thresholds for retraining and optimizing
 THRESHOLD_RETRAINING = 0.25
@@ -131,19 +132,11 @@ def calc_kpi_for_specific_pid(pid, start_time=None, end_time=None):
 
     # If predicted is empty, exit
     if len(predicted_load) == 0:
-        raise ValueError(
-            "Found no predicted load for pid {} between {} and {}!".format(
-                pj["id"], start_time, end_time
-            )
-        )
+        raise NoPredictionException(pid=pj["id"])
 
     # If realised is empty, exit
     if len(realised) == 0:
-        raise ValueError(
-            "Found no realised load for pid {} between {} and {}!".format(
-                pj["id"], start_time, end_time
-            )
-        )
+        raise NoLoadException(pid=pj["id"])
 
     # Calculate completeness en raise exception if completeness does not meet requirements
     completeness_realised = validation.calc_completeness(realised)

--- a/test/unit/tasks/test_calculate_kpi.py
+++ b/test/unit/tasks/test_calculate_kpi.py
@@ -116,7 +116,7 @@ class TestPerformanceCalcKpiForSpecificPid(BaseTestCase):
         self.assertAlmostEqual(kpis["4.0h"]["MAE"], 2.9145, places=3)
 
     @patch("openstf.tasks.calculate_kpi.DataBase", get_database_mock_realised_empty)
-    def test_calc_kpi_correct_exceptions(self):
+    def test_calc_kpi_no_load_exception(self):
         """Assert that correct exceptions are raised for
         empty load"""
 
@@ -124,7 +124,7 @@ class TestPerformanceCalcKpiForSpecificPid(BaseTestCase):
             calc_kpi_for_specific_pid({"id": 295})
 
     @patch("openstf.tasks.calculate_kpi.DataBase", get_database_mock_predicted_empty)
-    def test_calc_kpi_correct_exceptions(self):
+    def test_calc_kpi_no_prediction_exception(self):
         """Assert that correct exceptions are raised for
         empty prediction"""
 


### PR DESCRIPTION
Made reusable, custom exception. 

Considered also improving the teams logging message, to show all separate exceptions individually. Did not implement this, since we don't want to keep using teams as primary monitoring solution but something based on logs, e.g. Kibana. Exceptions are already individually logged.