### PR TITLE
Update optimize_hyperparameters.py

### DIFF
--- a/openstf/tasks/optimize_hyperparameters.py
+++ b/openstf/tasks/optimize_hyperparameters.py
@@ -42,7 +42,7 @@ def optimize_hyperparameters_task(pj: dict, context: TaskContext) -> None:
 
     # Determine if we need to optimize hyperparams
     datetime_last_optimized = context.database.get_hyper_params_last_optimized(pj)
-    if last_optimized_days is not None:
+    if datetime_last_optimized is not None:
         last_optimized_days = (datetime.utcnow() - datetime_last_optimized).days
         if last_optimized_days < MAX_AGE_HYPER_PARAMS_DAYS:
             context.logger.warning(

--- a/openstf/tasks/optimize_hyperparameters.py
+++ b/openstf/tasks/optimize_hyperparameters.py
@@ -42,16 +42,16 @@ def optimize_hyperparameters_task(pj: dict, context: TaskContext) -> None:
 
     # Determine if we need to optimize hyperparams
     datetime_last_optimized = context.database.get_hyper_params_last_optimized(pj)
-    last_optimized_days = (datetime.utcnow() - datetime_last_optimized).days
-
-    if last_optimized_days < MAX_AGE_HYPER_PARAMS_DAYS:
-        context.logger.warning(
-            "Skip hyperparameter optimization",
-            pid=pj["id"],
-            last_optimized_days=last_optimized_days,
-            max_age=MAX_AGE_HYPER_PARAMS_DAYS,
-        )
-        return
+    if last_optimized_days is not None:
+        last_optimized_days = (datetime.utcnow() - datetime_last_optimized).days
+        if last_optimized_days < MAX_AGE_HYPER_PARAMS_DAYS:
+            context.logger.warning(
+                "Skip hyperparameter optimization",
+                pid=pj["id"],
+                last_optimized_days=last_optimized_days,
+                max_age=MAX_AGE_HYPER_PARAMS_DAYS,
+            )
+            return
 
     # Get input data (usese "id" and "model")
     current_hyperparams = context.database.get_hyper_params(pj)


### PR DESCRIPTION
Spotted this bug on prd.
If no last_optimized is available, an exception is thrown, while we desire the optimization pipeline to proceed.

![image](https://user-images.githubusercontent.com/18208480/128326734-be92f14b-b8a2-48a7-9ef5-9696e43f8890.png)
