### PR TITLE
raise clear exception on unimplemented model

### DIFF
--- a/openstf/model/objective_creator.py
+++ b/openstf/model/objective_creator.py
@@ -13,6 +13,14 @@ class ObjectiveCreator:
 
     @staticmethod
     def create_objective(model_type: Union[MLModelType, str]) -> RegressorObjective:
+        if model_type not in ObjectiveCreator.OBJECTIVES.keys():
+            raise NotImplementedError(
+                "This model_type is not implemented "
+                "for hyperparam optimization."
+                f"Received: {model_type}, "
+                "Should be in: "
+                f"{list(ObjectiveCreator.OBJECTIVES.keys())}"
+            )
         model_type = MLModelType(model_type)
 
         return ObjectiveCreator.OBJECTIVES[model_type]

--- a/openstf/model/objective_creator.py
+++ b/openstf/model/objective_creator.py
@@ -13,13 +13,11 @@ class ObjectiveCreator:
 
     @staticmethod
     def create_objective(model_type: Union[MLModelType, str]) -> RegressorObjective:
-        if model_type not in ObjectiveCreator.OBJECTIVES.keys():
+        valid_types = list(ObjectiveCreator.OBJECTIVES.keys())
+        if model_type not in valid_types:
             raise NotImplementedError(
-                "This model_type is not implemented "
-                "for hyperparam optimization."
-                f"Received: {model_type}, "
-                "Should be in: "
-                f"{list(ObjectiveCreator.OBJECTIVES.keys())}"
+                f"No objective function for {model_type} valid model_types are:"
+                f"{', '.join([t.value for t in valid_types])}"
             )
         model_type = MLModelType(model_type)
 

--- a/test/unit/model/test_objective_creator.py
+++ b/test/unit/model/test_objective_creator.py
@@ -16,7 +16,7 @@ class TestObjectiveCreator(BaseTestCase):
         self.assertEqual(Objective, XGBRegressorObjective)
 
     def test_create_objective_not_implemented_model_type(self):
-        """Test if a nice error is returned if an nit-implemented model is requested"""
+        """Test if a nice error is returned if a not-implemented model is requested"""
         with self.assertRaises(NotImplementedError):
             ObjectiveCreator.create_objective("AnUnimplementedModelType")
 

--- a/test/unit/model/test_objective_creator.py
+++ b/test/unit/model/test_objective_creator.py
@@ -15,7 +15,7 @@ class TestObjectiveCreator(BaseTestCase):
         Objective = ObjectiveCreator.create_objective(MLModelType.XGB)
         self.assertEqual(Objective, XGBRegressorObjective)
 
-    def test_create_objective_all_model_types(self):
+    def test_create_objective_not_implemented_model_type(self):
         """Test if a nice error is returned if an nit-implemented model is requested"""
         with self.assertRaises(NotImplementedError):
             ObjectiveCreator.create_objective("AnUnimplementedModelType")

--- a/test/unit/model/test_objective_creator.py
+++ b/test/unit/model/test_objective_creator.py
@@ -7,13 +7,18 @@ from test.utils.base import BaseTestCase
 
 from openstf.enums import MLModelType
 from openstf.model.objective_creator import ObjectiveCreator
-from openstf.model.objective import XGBRegressorObjective
+from openstf.model.objective import XGBRegressorObjective, RegressorObjective
 
 
 class TestObjectiveCreator(BaseTestCase):
-    def test_create_objective(self):
+    def test_create_objective_happy(self):
         Objective = ObjectiveCreator.create_objective(MLModelType.XGB)
         self.assertEqual(Objective, XGBRegressorObjective)
+
+    def test_create_objective_all_model_types(self):
+        """Test if a nice error is returned if an nit-implemented model is requested"""
+        with self.assertRaises(NotImplementedError):
+            ObjectiveCreator.create_objective("AnUnimplementedModelType")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hyperparameter optimization for model_types other than xgb are not yet implemented.
I created a follow-up story to implement that functionality (https://alliander.atlassian.net/browse/KTPS-1543)

In this PR, I at least specified a clear NotImplementedException, and added a unit test for this exception.