### PR TITLE
if multiple exceptions are raised in a task, present an overview of pids per exception in teams message

### DIFF
--- a/openstf/tasks/utils/predictionjobloop.py
+++ b/openstf/tasks/utils/predictionjobloop.py
@@ -4,6 +4,7 @@
 
 import random
 import sys
+from collections import defaultdict
 
 
 class PredictionJobLoop:
@@ -106,6 +107,7 @@ class PredictionJobLoop:
         """
         pids_successful = []
         pids_unsuccessful = []
+        pids_unsuccessful_dict = defaultdict(list)
         last_job_exception = None
 
         num_jobs = len(self.prediction_jobs)
@@ -138,6 +140,7 @@ class PredictionJobLoop:
 
             except Exception as exception:
                 pids_unsuccessful.append(prediction_job["id"])
+                pids_unsuccessful_dict[str(exception)].append(prediction_job["id"])
                 last_job_exception = exception
 
                 self._handle_exception_during_iteration(prediction_job, exception)
@@ -168,6 +171,7 @@ class PredictionJobLoop:
                 "num_jobs": num_jobs,
                 "pids_successful": pids_successful,
                 "pids_unsuccessful": pids_unsuccessful,
+                "exceptions": pids_unsuccessful_dict,
                 "jobs_successful": jobs_successful,
                 "jobs_unsuccessful": jobs_unsuccessful,
                 "jobs_started": jobs_started,

--- a/openstf/tasks/utils/taskcontext.py
+++ b/openstf/tasks/utils/taskcontext.py
@@ -122,6 +122,17 @@ class TaskContext:
                     ]
                 }
             )
+            # Add details of exceptions and pids
+            string_pids_exceptions = "\n".join(
+                [f"{key}:{value}\n" for key, value in metrics["exceptions"].items()]
+            )
+            msg["sections"].append(
+                {
+                    "facts": [
+                        ("Exceptions: pid(s)", string_pids_exceptions),
+                    ]
+                }
+            )
 
         msg["sections"].append(
             {


### PR DESCRIPTION
added this functionality to the predictionloop + taskcontext, and added a unit test to test this.