### PR TITLE
Feature better exceptions train model pipeline

### DIFF
--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v1
     # Build documentation
     - name: Build documentation
-      uses: ammaraskar/sphinx-action@master
+      uses: ammaraskar/sphinx-action@0.4
       with:
         pre-build-command: |
           cp requirements.txt docs/requirements.txt &&\

--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -28,5 +28,7 @@ jobs:
         pre-build-command: |
           cp requirements.txt docs/requirements.txt &&\
           echo -e "\nsphinx_rtd_theme" >> docs/requirements.txt &&\
+          echo "DEBUG HERE" &&\
+          cat docs/requirements.txt &&\
           sphinx-apidoc -o docs openstf
         docs-folder: "docs/"

--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -23,11 +23,11 @@ jobs:
       uses: actions/checkout@v1
     # Build documentation
     - name: Build documentation
-      uses: ammaraskar/sphinx-action@0.4
+      uses: ammaraskar/sphinx-action@master
       with:
         pre-build-command: |
           cp requirements.txt docs/requirements.txt &&\
-          echo -e "\nsphinx_rtd_theme" >> docs/requirements.txt &&\
+          echo "sphinx_rtd_theme" >> docs/requirements.txt &&\
           echo "DEBUG HERE" &&\
           cat docs/requirements.txt &&\
           sphinx-apidoc -o docs openstf

--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: ammaraskar/sphinx-action@master
       with:
         pre-build-command: |
-          cp requirements.txt docs/requirements.txt
-          echo -e "\nsphinx_rtd_theme" >> docs/requirements.txt
+          cp requirements.txt docs/requirements.txt &&\
+          echo -e "\nsphinx_rtd_theme" >> docs/requirements.txt &&\
           sphinx-apidoc -o docs openstf
         docs-folder: "docs/"

--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -27,8 +27,6 @@ jobs:
       with:
         pre-build-command: |
           cp requirements.txt docs/requirements.txt &&\
-          echo "sphinx_rtd_theme" >> docs/requirements.txt &&\
-          echo "DEBUG HERE" &&\
-          cat docs/requirements.txt &&\
+          printf "\nsphinx_rtd_theme\n" >> docs/requirements.txt &&\
           sphinx-apidoc -o docs openstf
         docs-folder: "docs/"

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -20,8 +20,8 @@ jobs:
       uses: ammaraskar/sphinx-action@master
       with:
         pre-build-command: |
-          cp requirements.txt docs/requirements.txt
-          echo -e "\nsphinx_rtd_theme" >> docs/requirements.txt
+          cp requirements.txt docs/requirements.txt &&\
+          printf "\nsphinx_rtd_theme\n" >> docs/requirements.txt &&\
           sphinx-apidoc -o docs openstf
         docs-folder: "docs/"
     # Upload artifact so it is available from the action-window

--- a/openstf/exceptions.py
+++ b/openstf/exceptions.py
@@ -10,7 +10,7 @@ from typing import Union
 
 
 # Define custom exception
-class NoPredictionException(Exception):
+class NoPredictionError(Exception):
     """Custom exception if no historic predictions are available
     Attributes:
         pid -- prediction job id for which the exception occurred
@@ -27,7 +27,7 @@ class NoPredictionException(Exception):
         super().__init__(self.message)
 
 
-class NoLoadException(Exception):
+class NoLoadError(Exception):
     """Custom Exception if no historic load is available
     Attributes:
         pid -- prediction job id for which the exception occurred

--- a/openstf/exceptions.py
+++ b/openstf/exceptions.py
@@ -2,46 +2,17 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-"""Define custom exception classes.
-These are not complete, but will be added on a case by case basis
+"""openstf custom exceptions
 """
-
-from typing import Union
 
 
 # Define custom exception
-class NoPredictionError(Exception):
-    """Custom exception if no historic predictions are available
-    Attributes:
-        pid -- prediction job id for which the exception occurred
-        message -- explanation of the error
-    """
-
-    def __init__(
-        self,
-        pid: Union[int, str],
-        message: str = "No historic predictions found." "Could not calc KPI",
-    ):
-        self.pid = pid
-        self.message = message
-        super().__init__(self.message)
+class NoPredictedLoadError(Exception):
+    """No predicted load for given datatime range"""
 
 
-class NoLoadError(Exception):
-    """Custom Exception if no historic load is available
-    Attributes:
-        pid -- prediction job id for which the exception occurred
-        message -- explanation of the error
-    """
-
-    def __init__(
-        self,
-        pid: Union[int, str],
-        message: str = "No historic load found." "Could not calc KPI",
-    ):
-        self.pid = pid
-        self.message = message
-        super().__init__(self.message)
+class NoRealisedLoadError(Exception):
+    """No realised load for given datetime range"""
 
 
 class InputDataInvalidError(Exception):

--- a/openstf/exceptions.py
+++ b/openstf/exceptions.py
@@ -8,6 +8,7 @@ These are not complete, but will be added on a case by case basis
 
 from typing import Union
 
+
 # Define custom exception
 class NoPredictionException(Exception):
     """Custom exception if no historic predictions are available
@@ -41,3 +42,19 @@ class NoLoadException(Exception):
         self.pid = pid
         self.message = message
         super().__init__(self.message)
+
+
+class InputDataInvalidError(Exception):
+    """Invalid input data"""
+
+
+class InputDataInsufficientError(InputDataInvalidError):
+    """Insufficient input data"""
+
+
+class InputDataWrongColumnOrderError(InputDataInvalidError):
+    """Wrong column order input data"""
+
+
+class OldModelHigherScoreError(Exception):
+    """Old model has a higher score then new model"""

--- a/openstf/model/confidence_interval_applicator.py
+++ b/openstf/model/confidence_interval_applicator.py
@@ -2,12 +2,11 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 from datetime import datetime
-import pytz
 from typing import List
-import structlog
 
 import numpy as np
 import pandas as pd
+import structlog
 from scipy import stats
 from sklearn.base import RegressorMixin
 
@@ -54,7 +53,7 @@ class ConfidenceIntervalApplicator:
                 mostly used for a basecase forecast
 
         Returns:
-            pd.DataFrame: Forecast DataFram with columns: "forecast", "stdev" and
+            pd.DataFrame: Forecast DataFrame with columns: "forecast", "stdev" and
                 quantile columns
 
         """

--- a/openstf/model/serializer.py
+++ b/openstf/model/serializer.py
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: MPL-2.0
 from abc import ABC, abstractmethod
 from datetime import datetime
-import pytz
 from pathlib import Path
 from typing import List, Optional, Union
 
 import joblib
+import pytz
 import structlog
 from sklearn.base import RegressorMixin
 
@@ -230,7 +230,7 @@ class PersistentStorageSerializer(AbstractSerializer):
         self,
         pid: Union[int, str],
         limit: Optional[int] = 1,
-        ascending: Optional[bool] = True,
+        ascending: Optional[bool] = False,
     ) -> List[Path]:
         model_paths = [
             f / MODEL_FILENAME for f in self.find_model_folders(pid, ascending)

--- a/openstf/pipeline/train_model.py
+++ b/openstf/pipeline/train_model.py
@@ -3,17 +3,22 @@
 # SPDX-License-Identifier: MPL-2.0
 import logging
 from pathlib import Path
-from typing import List, Union, Tuple
+from typing import List, Tuple, Union
 
 import pandas as pd
-from sklearn.base import RegressorMixin
 import structlog
+from sklearn.base import RegressorMixin
 
+from openstf.exceptions import (
+    InputDataInsufficientError,
+    InputDataWrongColumnOrderError,
+    OldModelHigherScoreError,
+)
 from openstf.feature_engineering.feature_applicator import TrainFeatureApplicator
-from openstf.model.standard_deviation_generator import StandardDeviationGenerator
+from openstf.metrics.reporter import Report, Reporter
 from openstf.model.model_creator import ModelCreator
-from openstf.metrics.reporter import Reporter, Report
 from openstf.model.serializer import PersistentStorageSerializer
+from openstf.model.standard_deviation_generator import StandardDeviationGenerator
 from openstf.model_selection.model_selection import split_data_train_validation_test
 from openstf.validation import validation
 
@@ -72,7 +77,7 @@ def train_model_pipeline(
     # Train model with core pipeline
     try:
         model, report = train_model_pipeline_core(pj, input_data, old_model)
-    except RuntimeError as e:
+    except OldModelHigherScoreError as e:
         logger.error(f"Old model is better than new model for {pj['name']}", exc_info=e)
         return
 
@@ -110,8 +115,9 @@ def train_model_pipeline_core(
         horizons (List[float]): horizons to train on in hours.
 
     Raises:
-        ValueError: When input data is insufficient
-        RuntimeError: When old model is better than new model
+        InputDataInsufficientError: when input data is insufficient.
+        InputDataWrongColumnOrderError: when input data has a invalid column order.
+        OldModelHigherScoreError: When old model is better than new model
 
     Returns:
         Tuple[RegressorMixin, Report]: Trained model and report (with figures)
@@ -146,7 +152,7 @@ def train_model_pipeline_core(
             # Check if R^2 is better for old model
             if score_old_model > score_new_model * PENALTY_FACTOR_OLD_MODEL:
                 raise (
-                    RuntimeError(
+                    OldModelHigherScoreError(
                         f"Old model is better than new model for {pj['name']}."
                         f"NOT updating model"
                     )
@@ -182,6 +188,9 @@ def train_pipeline_common(
         Tuple[RegressorMixin, pd.DataFrame, pd.DataFrame, pd.DataFrame]: Trained model,
          train_data, validation_data and test_data
 
+    Raises:
+        InputDataInsufficientError: when input data is insufficient.
+        InputDataWrongColumnOrderError: when input data has a invalid column order.
 
     """
 
@@ -190,7 +199,7 @@ def train_pipeline_common(
 
     # Check if sufficient data is left after cleaning
     if not validation.is_data_sufficient(validated_data):
-        raise ValueError(
+        raise InputDataInsufficientError(
             f"Input data is insufficient for {pj['name']} "
             f"after validation and cleaning"
         )
@@ -207,15 +216,14 @@ def train_pipeline_common(
         backtest=backtest,
     )
 
-    # Create relevant model
-    model = ModelCreator.create_model(pj["model"], quantiles=pj["quantiles"])
-
     # Test if first column is "load" and last column is "horizon"
     if train_data.columns[0] != "load" or train_data.columns[-1] != "horizon":
-        raise RuntimeError(
-            "Column order in train input data not as expected, "
-            "could not train a model!"
+        raise InputDataWrongColumnOrderError(
+            "'load' column should be first and 'horizon' column last."
         )
+
+    # Create relevant model
+    model = ModelCreator.create_model(pj["model"], quantiles=pj["quantiles"])
 
     # split x and y data
     train_x, train_y = train_data.iloc[:, 1:-1], train_data.iloc[:, 0]

--- a/openstf/pipeline/train_model.py
+++ b/openstf/pipeline/train_model.py
@@ -117,7 +117,7 @@ def train_model_pipeline_core(
     Raises:
         InputDataInsufficientError: when input data is insufficient.
         InputDataWrongColumnOrderError: when input data has a invalid column order.
-        OldModelHigherScoreError: When old model is better than new model
+        OldModelHigherScoreError: When old model is better than new model.
 
     Returns:
         Tuple[RegressorMixin, Report]: Trained model and report (with figures)

--- a/openstf/tasks/calculate_kpi.py
+++ b/openstf/tasks/calculate_kpi.py
@@ -138,13 +138,13 @@ def calc_kpi_for_specific_pid(pid, start_time=None, end_time=None):
     # If predicted is empty
     if len(predicted_load) == 0:
         raise NoPredictedLoadError(
-            f"No predicted load found for {pid} from {start_time} to {end_time}"
+            f"No predicted load found for {pid} from {start_time} to {end_time}."
         )
 
     # If realised is empty
     if len(realised) == 0:
         raise NoRealisedLoadError(
-            f"No realised load found for {pid} from {start_time} to {end_time}"
+            f"No realised load found for {pid} from {start_time} to {end_time}."
         )
 
     completeness_realised = validation.calc_completeness(realised)

--- a/openstf/tasks/calculate_kpi.py
+++ b/openstf/tasks/calculate_kpi.py
@@ -31,7 +31,7 @@ from openstf.validation import validation
 from openstf.metrics import metrics
 from openstf.tasks.utils.predictionjobloop import PredictionJobLoop
 from openstf.tasks.utils.taskcontext import TaskContext
-from openstf.exceptions import NoLoadException, NoPredictionException
+from openstf.exceptions import NoLoadError, NoPredictionError
 
 # Thresholds for retraining and optimizing
 THRESHOLD_RETRAINING = 0.25
@@ -132,11 +132,11 @@ def calc_kpi_for_specific_pid(pid, start_time=None, end_time=None):
 
     # If predicted is empty, exit
     if len(predicted_load) == 0:
-        raise NoPredictionException(pid=pj["id"])
+        raise NoPredictionError(pid=pj["id"])
 
     # If realised is empty, exit
     if len(realised) == 0:
-        raise NoLoadException(pid=pj["id"])
+        raise NoLoadError(pid=pj["id"])
 
     # Calculate completeness en raise exception if completeness does not meet requirements
     completeness_realised = validation.calc_completeness(realised)

--- a/openstf/tasks/create_forecast.py
+++ b/openstf/tasks/create_forecast.py
@@ -30,11 +30,11 @@ Attributes:
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from openstf.enums import MLModelType
 from openstf.pipeline.create_forecast import create_forecast_pipeline
-from openstf.tasks.utils.utils import check_status_change, update_status_change
 from openstf.tasks.utils.predictionjobloop import PredictionJobLoop
 from openstf.tasks.utils.taskcontext import TaskContext
-from openstf.enums import MLModelType
+from openstf.tasks.utils.utils import check_status_change, update_status_change
 
 T_BEHIND_DAYS: int = 14
 T_AHEAD_DAYS: int = 3
@@ -66,7 +66,6 @@ def create_forecast_task(pj: dict, context: TaskContext) -> None:
         datetime_start=datetime_start,
         datetime_end=datetime_end,
     )
-
     # Make forecast with the forecast pipeline
     forecast = create_forecast_pipeline(pj, input_data, trained_models_folder)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2017-2021 Alliander N.V. <korte.termijn.prognoses@alliander.com> # noqa E501
+#
+# SPDX-License-Identifier: MPL-2.0
+[tool.pylint.format]
+max-line-length = 88
+
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2017-2021 Alliander N.V. <korte.termijn.prognoses@alliander.com> # noqa E501
 #
 # SPDX-License-Identifier: MPL-2.0
-
-[pycodestyle]
-max_line_length = 88
 [flake8]
 max_line_length = 88
 max_complexity = 10

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 from pathlib import Path
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 pkg_dir = Path(__file__).parent.absolute()
 
@@ -28,7 +29,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstf",
-    version="2.2.1",
+    version="2.2.2",
     packages=find_packages(include=["openstf", "openstf.*"]),
     description="Open short term forcasting",
     long_description=read_long_description_from_readme(),

--- a/test/unit/pipeline/test_train_model.py
+++ b/test/unit/pipeline/test_train_model.py
@@ -1,22 +1,20 @@
 # SPDX-FileCopyrightText: 2017-2021 Alliander N.V. <korte.termijn.prognoses@alliander.com> # noqa E501>
 #
 # SPDX-License-Identifier: MPL-2.0
-from datetime import datetime, timedelta
 import unittest
+from datetime import datetime, timedelta
+from test.utils import BaseTestCase, TestData
 from unittest.mock import MagicMock, patch
-from test.utils import TestData
-from test.utils import BaseTestCase
 
 import pandas as pd
 import sklearn
 
-from openstf.pipeline.train_model import (
-    train_model_pipeline_core,
-    train_model_pipeline,
-    split_data_train_validation_test,
-)
 from openstf.metrics.reporter import Report
-
+from openstf.pipeline.train_model import (
+    split_data_train_validation_test,
+    train_model_pipeline,
+    train_model_pipeline_core,
+)
 
 # define constants
 
@@ -65,6 +63,7 @@ class TestTrainModelPipeline(BaseTestCase):
         self.assertEqual(len(validation_data), 1297)
         self.assertEqual(len(test_data), 1)
 
+    # TODO move to model_selction unit test
     def test_split_data_train_validation_test_period(self):
         train_data, validation_data, test_data = split_data_train_validation_test(
             self.data, period_sampling=True

--- a/test/unit/tasks/test_calculate_kpi.py
+++ b/test/unit/tasks/test_calculate_kpi.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from openstf.tasks.calculate_kpi import calc_kpi_for_specific_pid
-from openstf.exceptions import NoLoadException, NoPredictionException
+from openstf.exceptions import NoLoadError, NoPredictionError
 from test.utils import BaseTestCase, TestData
 
 # Get test data
@@ -120,7 +120,7 @@ class TestPerformanceCalcKpiForSpecificPid(BaseTestCase):
         """Assert that correct exceptions are raised for
         empty load"""
 
-        with self.assertRaises(NoLoadException):
+        with self.assertRaises(NoLoadError):
             calc_kpi_for_specific_pid({"id": 295})
 
     @patch("openstf.tasks.calculate_kpi.DataBase", get_database_mock_predicted_empty)
@@ -128,7 +128,7 @@ class TestPerformanceCalcKpiForSpecificPid(BaseTestCase):
         """Assert that correct exceptions are raised for
         empty prediction"""
 
-        with self.assertRaises(NoPredictionException):
+        with self.assertRaises(NoPredictionError):
             calc_kpi_for_specific_pid({"id": 295})
 
 

--- a/test/unit/tasks/test_calculate_kpi.py
+++ b/test/unit/tasks/test_calculate_kpi.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from openstf.tasks.calculate_kpi import calc_kpi_for_specific_pid
-from openstf.exceptions import NoLoadError, NoPredictionError
+from openstf.exceptions import NoRealisedLoadError, NoPredictedLoadError
 from test.utils import BaseTestCase, TestData
 
 # Get test data
@@ -120,7 +120,7 @@ class TestPerformanceCalcKpiForSpecificPid(BaseTestCase):
         """Assert that correct exceptions are raised for
         empty load"""
 
-        with self.assertRaises(NoLoadError):
+        with self.assertRaises(NoRealisedLoadError):
             calc_kpi_for_specific_pid({"id": 295})
 
     @patch("openstf.tasks.calculate_kpi.DataBase", get_database_mock_predicted_empty)
@@ -128,7 +128,7 @@ class TestPerformanceCalcKpiForSpecificPid(BaseTestCase):
         """Assert that correct exceptions are raised for
         empty prediction"""
 
-        with self.assertRaises(NoPredictionError):
+        with self.assertRaises(NoPredictedLoadError):
             calc_kpi_for_specific_pid({"id": 295})
 
 


### PR DESCRIPTION
This PR adds better exceptions to the train model pipeline functions.

**OLD exceptions**

* `ValueError` When input data is insufficient
* `RuntimeError`: When old model is better than new model
* `RuntimeError`: When column order is incorrect

**NEW expceptions**
* `InputDataInsufficientError`: when input data is insufficient.
* `InputDataWrongColumnOrderError`: when input data has a invalid column order.
* `OldModelHigherScoreError`: When old model is better than new model.

Especially the identical RuntimeError for two different reasons has been problematic when client codes calls the train model pipeline. (This PR is required to solve some issues in our openstf api code)

> NOTE: In order to use these improvements staighaway I want to make a v2.2.2 release after merging this PR.
