### PR TITLE
Feature ktps 1548 error formatting

### DIFF
--- a/.github/workflows/reuse-compliance.yaml
+++ b/.github/workflows/reuse-compliance.yaml
@@ -5,7 +5,6 @@ name: REUSE Compliance Check
 
 on:
   - push
-  - pull_request
 
 jobs:
   test:

--- a/openstf/exceptions.py
+++ b/openstf/exceptions.py
@@ -5,15 +5,21 @@
 """openstf custom exceptions
 """
 
-
 # Define custom exception
 class NoPredictedLoadError(Exception):
     """No predicted load for given datatime range"""
 
+    def __init__(self, pid, message="No predicted load found"):
+        self.pid = pid
+        self.message = message
+        super().__init__(self.message)
 
 class NoRealisedLoadError(Exception):
     """No realised load for given datetime range"""
-
+    def __init__(self, pid, message="No realised load found"):
+        self.pid = pid
+        self.message = message
+        super().__init__(self.message)
 
 class InputDataInvalidError(Exception):
     """Invalid input data"""

--- a/openstf/exceptions.py
+++ b/openstf/exceptions.py
@@ -13,7 +13,6 @@ class NoPredictedLoadError(Exception):
         self.pid = pid
         self.start_time = start_time
         self.end_time = end_time
-        print(f"No predicted load found for {pid} from {start_time} to {end_time}.")
         self.message = message
         super().__init__(self.message)
 
@@ -23,7 +22,6 @@ class NoRealisedLoadError(Exception):
         self.pid = pid
         self.start_time = start_time
         self.end_time = end_time
-        print(f"No realised load found for {pid} from {start_time} to {end_time}.")
         self.message = message
         super().__init__(self.message)
 

--- a/openstf/exceptions.py
+++ b/openstf/exceptions.py
@@ -8,16 +8,15 @@
 # Define custom exception
 class NoPredictedLoadError(Exception):
     """No predicted load for given datatime range"""
-
-    def __init__(self, pid, message="No predicted load found"):
-        self.pid = pid
+    def __init__(self, pid: int, message: str ="No predicted load found") -> Exception:
+        self.pid = pid # unused
         self.message = message
         super().__init__(self.message)
 
 class NoRealisedLoadError(Exception):
     """No realised load for given datetime range"""
-    def __init__(self, pid, message="No realised load found"):
-        self.pid = pid
+    def __init__(self, pid: int, message: str ="No realised load found") -> Exception:
+        self.pid = pid # unused
         self.message = message
         super().__init__(self.message)
 

--- a/openstf/exceptions.py
+++ b/openstf/exceptions.py
@@ -4,19 +4,26 @@
 
 """openstf custom exceptions
 """
+from datetime import datetime
 
 # Define custom exception
 class NoPredictedLoadError(Exception):
     """No predicted load for given datatime range"""
-    def __init__(self, pid: int, message: str ="No predicted load found") -> Exception:
-        self.pid = pid # unused
+    def __init__(self, pid: int, start_time: datetime, end_time: datetime, message: str ="No predicted load found") -> Exception:
+        self.pid = pid
+        self.start_time = start_time
+        self.end_time = end_time
+        print(f"No predicted load found for {pid} from {start_time} to {end_time}.")
         self.message = message
         super().__init__(self.message)
 
 class NoRealisedLoadError(Exception):
     """No realised load for given datetime range"""
-    def __init__(self, pid: int, message: str ="No realised load found") -> Exception:
-        self.pid = pid # unused
+    def __init__(self, pid: int, start_time: datetime, end_time: datetime, message: str ="No realised load found") -> Exception:
+        self.pid = pid
+        self.start_time = start_time
+        self.end_time = end_time
+        print(f"No realised load found for {pid} from {start_time} to {end_time}.")
         self.message = message
         super().__init__(self.message)
 

--- a/openstf/tasks/calculate_kpi.py
+++ b/openstf/tasks/calculate_kpi.py
@@ -138,13 +138,13 @@ def calc_kpi_for_specific_pid(pid, start_time=None, end_time=None):
     # If predicted is empty
     if len(predicted_load) == 0:
         raise NoPredictedLoadError(
-            f"No predicted load found for {pid} from {start_time} to {end_time}."
+            pid
         )
 
     # If realised is empty
     if len(realised) == 0:
         raise NoRealisedLoadError(
-            f"No realised load found for {pid} from {start_time} to {end_time}."
+            pid
         )
 
     completeness_realised = validation.calc_completeness(realised)

--- a/openstf/tasks/calculate_kpi.py
+++ b/openstf/tasks/calculate_kpi.py
@@ -138,13 +138,13 @@ def calc_kpi_for_specific_pid(pid, start_time=None, end_time=None):
     # If predicted is empty
     if len(predicted_load) == 0:
         raise NoPredictedLoadError(
-            pid
+            pid, start_time, end_time
         )
 
     # If realised is empty
     if len(realised) == 0:
         raise NoRealisedLoadError(
-            pid
+            pid, start_time, end_time
         )
 
     completeness_realised = validation.calc_completeness(realised)

--- a/test/unit/tasks/utils/test_task_context.py
+++ b/test/unit/tasks/utils/test_task_context.py
@@ -85,6 +85,7 @@ class TestTaskContext(BaseTestCase):
         pids they are nicely grouped per exception type."""
         # Specify which types of exceptions are raised
         func_fail = Mock()
+        # the int/pid is arbitrary, unused currently.
         func_fail.side_effect = [
             None,
             NoPredictedLoadError(2),
@@ -104,20 +105,20 @@ class TestTaskContext(BaseTestCase):
 
         with self.assertRaises(PredictionJobException):
             with TaskContext("test_with_teams_message", False, True) as context:
-                PredictionJobLoop(context, prediction_jobs=test_prediction_jobs).map(
+                PredictionJobLoop(context, prediction_jobs=test_prediction_jobs, random_order=False).map(
                     func_fail
                 )
 
-            # Assert that specification of exception: [pids] is 'posted' to the postteamsmock
-            self.assertListEqual(
-                postteamsmock.call_args_list[0].args[0]["sections"][2]["facts"],
-                [
-                    (
-                        "Exceptions: pid(s)",
-                        "Forced error:[3, 4]\n\nDifferent Forced error:[1]\n",
-                    )
-                ],
-            )
+        # Assert that specification of exception: [pids] is 'posted' to the postteamsmock
+        self.assertListEqual(
+            postteamsmock.call_args_list[0].args[0]["sections"][2]["facts"],
+            [
+                (
+                    "Exceptions: pid(s)",
+                    "No predicted load found:[2, 3]\n\nNo realised load found:[4]\n",
+                )
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/test/unit/tasks/utils/test_task_context.py
+++ b/test/unit/tasks/utils/test_task_context.py
@@ -6,6 +6,7 @@
 import unittest
 from test.utils import TestData
 from unittest.mock import MagicMock, Mock, patch
+from datetime import datetime, timedelta
 
 from openstf.tasks.utils.predictionjobloop import (
     PredictionJobLoop,
@@ -86,11 +87,13 @@ class TestTaskContext(BaseTestCase):
         # Specify which types of exceptions are raised
         func_fail = Mock()
         # the int/pid is arbitrary, unused currently.
+        start_time = datetime.utcnow()
+        end_time = datetime.utcnow() - timedelta(days=1)
         func_fail.side_effect = [
             None,
-            NoPredictedLoadError(2),
-            NoPredictedLoadError(3),
-            NoRealisedLoadError(4),
+            NoPredictedLoadError(2, start_time, end_time),
+            NoPredictedLoadError(3, start_time, end_time),
+            NoRealisedLoadError(4, start_time, end_time),
         ]
 
         # Specify test prediction jobs.

--- a/test/unit/tasks/utils/test_task_context.py
+++ b/test/unit/tasks/utils/test_task_context.py
@@ -11,6 +11,7 @@ from openstf.tasks.utils.predictionjobloop import (
     PredictionJobLoop,
     PredictionJobException,
 )
+from openstf.exceptions import NoPredictedLoadError, NoRealisedLoadError
 
 # import project modules
 from openstf.tasks.utils.taskcontext import TaskContext
@@ -86,9 +87,9 @@ class TestTaskContext(BaseTestCase):
         func_fail = Mock()
         func_fail.side_effect = [
             None,
-            ValueError("Forced error"),
-            ValueError("Forced error"),
-            NotImplementedError("Different Forced error"),
+            NoPredictedLoadError(2),
+            NoPredictedLoadError(3),
+            NoRealisedLoadError(4),
         ]
 
         # Specify test prediction jobs.


### PR DESCRIPTION
The formatting of the error handeling is changed to allow for easy listing of PID's encountering the same error.
Slightly adapted  the unit test for the changes.
@FrankKr please take a look at the exception classes, it now contains a print statement. Could be useful information but might be beter to write to a logfile?
  