### PR TITLE
Raise error if input data is empty at hyper parameter optimization

### DIFF
--- a/openstf/pipeline/optimize_hyperparameters.py
+++ b/openstf/pipeline/optimize_hyperparameters.py
@@ -51,6 +51,8 @@ def optimize_hyperparameters_pipeline(
     """
     if input_data.empty:
         raise ValueError("Input dataframe is empty")
+    elif "load" not in input_data.columns:
+        raise ValueError("Missing the load column in the input dataframe")
 
     # Validate and clean data
     validated_data = validation.clean(validation.validate(pj["id"], input_data))

--- a/openstf/pipeline/optimize_hyperparameters.py
+++ b/openstf/pipeline/optimize_hyperparameters.py
@@ -49,6 +49,9 @@ def optimize_hyperparameters_pipeline(
     Returns:
         dict: Optimized hyperparameters.
     """
+    if input_data.empty:
+        raise ValueError("Input dataframe is empty")
+
     # Validate and clean data
     validated_data = validation.clean(validation.validate(pj["id"], input_data))
 

--- a/test/unit/pipeline/test_optimize_hyperparameters.py
+++ b/test/unit/pipeline/test_optimize_hyperparameters.py
@@ -4,6 +4,8 @@
 import unittest
 from unittest.mock import patch
 
+import pandas as pd
+
 from test.utils import BaseTestCase, TestData
 from openstf.pipeline.optimize_hyperparameters import optimize_hyperparameters_pipeline
 
@@ -29,6 +31,17 @@ class TestOptimizeHyperParametersPipeline(BaseTestCase):
         pj = TestData.get_prediction_job(pid=307)
         input_data = TestData.load("input_data_train.pickle")
         # if data is not sufficient a ValueError should be raised
+        with self.assertRaises(ValueError):
+            optimize_hyperparameters_pipeline(pj, input_data)
+
+    def test_optimize_hyperparameters_pipeline_no_data(self, *args):
+        validation_mock = args[3]
+        validation_mock.is_data_sufficient.return_value = False
+
+        pj = TestData.get_prediction_job(pid=307)
+        input_data = pd.DataFrame()
+
+        # if there is no data a ValueError should be raised
         with self.assertRaises(ValueError):
             optimize_hyperparameters_pipeline(pj, input_data)
 

--- a/test/unit/pipeline/test_optimize_hyperparameters.py
+++ b/test/unit/pipeline/test_optimize_hyperparameters.py
@@ -45,6 +45,17 @@ class TestOptimizeHyperParametersPipeline(BaseTestCase):
         with self.assertRaises(ValueError):
             optimize_hyperparameters_pipeline(pj, input_data)
 
+    def test_optimize_hyperparameters_pipeline_no_load_data(self, *args):
+        validation_mock = args[3]
+        validation_mock.is_data_sufficient.return_value = False
+
+        pj = TestData.get_prediction_job(pid=307)
+        input_data = TestData.load("input_data_train.pickle")
+        input_data = input_data.drop("load", axis=1)
+        # if there is no data a ValueError should be raised
+        with self.assertRaises(ValueError):
+            optimize_hyperparameters_pipeline(pj, input_data)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit/pipeline/test_train_model.py
+++ b/test/unit/pipeline/test_train_model.py
@@ -11,6 +11,7 @@ import sklearn
 
 from openstf.enums import MLModelType
 from openstf.feature_engineering.feature_applicator import TrainFeatureApplicator
+from openstf.model_selection.model_selection import split_data_train_validation_test
 from openstf.validation import validation
 from openstf.metrics.reporter import Report
 from openstf.pipeline.train_model import (
@@ -95,7 +96,8 @@ class TestTrainModelPipeline(BaseTestCase):
                 ).add_features(validated_data)
 
                 # Split data
-                (
+                (   _,
+                    _,
                     train_data,
                     validation_data,
                     test_data,


### PR DESCRIPTION
Now raises a ValueError during hyperparameter optimization if dataframe is empty or doesn't contain a load column.