### PR TITLE
Bugfix ktps 1758 optimize hyperparams inf nan

### DIFF
--- a/openstf/pipeline/optimize_hyperparameters.py
+++ b/openstf/pipeline/optimize_hyperparameters.py
@@ -73,9 +73,9 @@ def optimize_hyperparameters_pipeline(
             f"after validation and cleaning"
         )
 
-    input_data_with_features = TrainFeatureApplicator(horizons=horizons).add_features(
-        input_data
-    )
+    validated_data_with_features = TrainFeatureApplicator(
+        horizons=horizons
+    ).add_features(validated_data)
 
     # Create objective (NOTE: this is a callable class)
     objective = ObjectiveCreator.create_objective(model_type=pj["model"])
@@ -85,7 +85,7 @@ def optimize_hyperparameters_pipeline(
 
     objective = objective(
         model,
-        input_data_with_features,
+        validated_data_with_features,
     )
 
     study = optuna.create_study(

--- a/openstf/tasks/utils/predictionjobloop.py
+++ b/openstf/tasks/utils/predictionjobloop.py
@@ -17,6 +17,7 @@ class PredictionJobLoop:
         on_successful_callback=None,
         on_end_callback=None,
         prediction_jobs=None,
+        debug_pid=None,
         **pj_kwargs
     ):
         """Convenience objects that maps a function over prediction jobs.
@@ -26,7 +27,7 @@ class PredictionJobLoop:
         function. If another set of prediction jobs is desired, manually pass
         them using the prediction_jobs argument.
 
-        Tip: For debugging a specific PID, use prediction_jobs=[dict(id={specific_pid})]
+        Tip: For debugging a specific PID, use debug_pid=specific_pid
 
         Args:
             context (openstf.tasks.util.taskcontext.TaskContext): The
@@ -46,9 +47,10 @@ class PredictionJobLoop:
                 iteration is completed. Callable gets the pj and and bool
                 indicating success as argument.
             prediction_jobs (list of dicts, optional): Manually pass a list of
-                prediction jobs that will be looped over. A prediction job is a dict
-                with at least a value set for the key `id`. If set to None, will fetch
-                prediction jobs from database.
+                prediction jobs that will be looped over. If set to None, will fetch
+                prediction jobs from database based on pj_kwargs
+            debug_pid (int): enter a specific pid for debugging.
+                If not None, the prediction job loop will only look at this pid
             **pj_kwargs: Any other kwargs willed will be directed to the
                 prediction job getting function.
 
@@ -60,6 +62,7 @@ class PredictionJobLoop:
         self.on_successful_callback = on_successful_callback
         self.on_end_callback = on_end_callback
         self.pj_kwargs = pj_kwargs
+        self.debug_pid = debug_pid
 
         if prediction_jobs is None:
             self.prediction_jobs = self._get_prediction_jobs()
@@ -74,7 +77,17 @@ class PredictionJobLoop:
         self.context.logger.info(
             "Querying prediction jobs from database", **self.pj_kwargs
         )
-        prediction_jobs = self.context.database.get_prediction_jobs(**self.pj_kwargs)
+        if self.debug_pid is not None:
+            prediction_jobs = self.context.database.get_prediction_jobs(
+                **self.pj_kwargs
+            )
+        else:
+            # retrieve prediction_job for single pid - useful for debugging
+            prediction_jobs = [
+                self.context.database.get_prediction_job(
+                    pid=self.debug_pid, **self.pj_kwargs
+                )
+            ]
 
         return prediction_jobs
 

--- a/openstf/tasks/utils/predictionjobloop.py
+++ b/openstf/tasks/utils/predictionjobloop.py
@@ -77,7 +77,7 @@ class PredictionJobLoop:
         self.context.logger.info(
             "Querying prediction jobs from database", **self.pj_kwargs
         )
-        if self.debug_pid is not None:
+        if self.debug_pid is None:
             prediction_jobs = self.context.database.get_prediction_jobs(
                 **self.pj_kwargs
             )

--- a/test/unit/tasks/utils/test_prediction_job_loop.py
+++ b/test/unit/tasks/utils/test_prediction_job_loop.py
@@ -94,6 +94,12 @@ class TestPredictionJob(BaseTestCase):
         self.assertEqual(on_successful_callback.call_count, 0)
         self.assertEqual(on_end_callback.call_count, 1)
 
+    def test_prediction_job_loop_debug_pid(self):
+        """Test if a list of prediction_jobs with len 1 is returned if debug_pid is given"""
+        context_mock = MagicMock()
+        pjl = PredictionJobLoop(context_mock, debug_pid=1)
+        self.assertEqual(len(pjl.prediction_jobs), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Cause for bug if nan values were in target:
Data was already being validated in the pipeline, but instead of using the validated data, the non-validated input was used

bonus: added functionality in PredictionJobLoop to debug a specific pid more easily