### PR TITLE
Remove modelage check from tasks\train_model.py

### DIFF
--- a/test/unit/tasks/test_train_model.py
+++ b/test/unit/tasks/test_train_model.py
@@ -25,31 +25,3 @@ class TestTrainModelTask(TestCase):
         self.assertEqual(
             train_model_pipeline_mock.call_args_list[0][0][0]["id"], self.pj["id"]
         )
-
-    @patch(
-        "openstf.tasks.train_model.get_model_age", return_value=MAXIMUM_MODEL_AGE - 1
-    )
-    @patch("openstf.tasks.train_model.train_model_pipeline")
-    def test_train_model_task_recent_old_model(
-        self, train_model_pipeline_mock, get_model_age_mock
-    ):
-        """If an old model exists which is recent, abort the training immediately."""
-        # Test happy flow of create forecast task
-        context = MagicMock()
-        train_model_task(self.pj, context)
-        # Assert that the context is not called. This would be the case if input data was retrieved
-        context.database.get_model_input.assert_not_called()
-
-    @patch(
-        "openstf.tasks.train_model.get_model_age", return_value=MAXIMUM_MODEL_AGE + 1
-    )
-    @patch("openstf.tasks.train_model.train_model_pipeline")
-    def test_train_model_task_no_recent_old_model(
-        self, train_model_pipeline_mock, get_model_age_mock
-    ):
-        """If an old model exists but is not recent, training should continue."""
-        # Test happy flow of create forecast task
-        context = MagicMock()
-        train_model_task(self.pj, context)
-        # Assert that the context is called. This would be the case if input data was retrieved
-        context.database.get_model_input.assert_called()


### PR DESCRIPTION
The model check is now only done in the pipeline\train_model